### PR TITLE
Added Supabase connection

### DIFF
--- a/BackEnd/f1-api/pom.xml
+++ b/BackEnd/f1-api/pom.xml
@@ -30,37 +30,45 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+		<!-- Web (REST controllers, embedded Tomcat) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- Spring Security -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+
+		<!-- OAuth2 Client (for Google login later) -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-oauth2-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
+			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
 
+		<!-- JPA + Hibernate -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<!-- PostgreSQL driver (for Supabase) -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-oauth2-client-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/BackEnd/f1-api/src/main/java/com/team1/f1_api/controller/TrackController.java
+++ b/BackEnd/f1-api/src/main/java/com/team1/f1_api/controller/TrackController.java
@@ -1,17 +1,22 @@
 package com.team1.f1_api.controller;
 
 import com.team1.f1_api.model.Track;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.team1.f1_api.repository.TrackRepository;
 import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/tracks")
 public class TrackController {
+
+    private final TrackRepository trackRepository;
+
+    public TrackController(TrackRepository trackRepository) {
+        this.trackRepository = trackRepository;
+    }
+
     @GetMapping
-    public List<Track> getTracks() {
-        return List.of(new Track("1", "Monza", "IT"));
-    } //Hard coded data to return for now
+    public List<Track> getAllTracks() {
+        return trackRepository.findAll();
+    }
 }

--- a/BackEnd/f1-api/src/main/java/com/team1/f1_api/model/Track.java
+++ b/BackEnd/f1-api/src/main/java/com/team1/f1_api/model/Track.java
@@ -1,23 +1,48 @@
 package com.team1.f1_api.model;
 
+import jakarta.persistence.*;
 
-//Track class with id, name, countryID for now
+@Entity
+@Table(name = "tracks")
 public class Track {
-    private String id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long trackId;
+
     private String name;
-    private String countryID;
-    public Track(String id, String name, String countryID){
-        this.id = id;
-        this.name = name;
-        this.countryID = countryID;
+
+    private String shortName;
+
+    private Double lengthKm;
+
+    private String surfaceType;
+
+    private Integer configCount;
+
+    public Track() {}
+
+    public Long getTrackId() {
+        return trackId;
     }
-    public String getId(){
-        return id;
-    }
-    public String getName(){
+
+    public String getName() {
         return name;
     }
-    public String getCountryID(){
-        return countryID;
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public Double getLengthKm() {
+        return lengthKm;
+    }
+
+    public String getSurfaceType() {
+        return surfaceType;
+    }
+
+    public Integer getConfigCount() {
+        return configCount;
     }
 }

--- a/BackEnd/f1-api/src/main/java/com/team1/f1_api/repository/TrackRepository.java
+++ b/BackEnd/f1-api/src/main/java/com/team1/f1_api/repository/TrackRepository.java
@@ -1,0 +1,6 @@
+package com.team1.f1_api.repository;
+
+import com.team1.f1_api.model.Track;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackRepository extends JpaRepository<Track, Long> {}

--- a/BackEnd/f1-api/src/main/resources/application.properties
+++ b/BackEnd/f1-api/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=f1-api
+
+# ===============================
+# Supabase PostgreSQL Connection (Session Pooler - IPv4 compatible)
+# ===============================
+
+spring.datasource.url=jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:5432/postgres?sslmode=require
+spring.datasource.username=postgres.eytlhjybvmmmtcvbxyyr
+spring.datasource.password=MotoRYX2026
+
+# ===============================
+# JPA / Hibernate Configuration
+# ===============================
+
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+spring.jpa.open-in-view=false


### PR DESCRIPTION
Precondition: Got the Spring Boot backend connected to Supabase PostgreSQL. Fixed several broken dependencies in pom.xml, standardized package names across all files so Spring could actually find and register the controllers, and updated application.properties to use Supabase's Session Pooler URL since the direct connection doesn't support IPv4. The `GET /tracks` endpoint is now live and returning real data from the database.

Postcondition: Add more tables to Supabase, populate them with real data, define the relationships between them, and expose new endpoints to query that data.

Key Changes:

 - Fixed invalid dependency names in pom.xml
 - Standardized package names across all source files to com.team1.f1_api
 - Updated application.properties to use Supabase Session Pooler URL (IPv4 compatible)
 - Track entity, TrackRepository, and TrackController wired up end-to-end


Closes #27, Closes #13