### PR TITLE
Updated database configuration to use Spring Boot standard environmen…

### DIFF
--- a/BackEnd/f1-api/src/main/resources/application.properties
+++ b/BackEnd/f1-api/src/main/resources/application.properties
@@ -11,16 +11,16 @@ server.port=${PORT:8080}
 
 # ===============================
 # Supabase PostgreSQL Connection
-# Reads credentials from environment variables for security.
-# For local development, set these in your shell or create a .env file:
-#   export SUPABASE_DB_URL=jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:5432/postgres?sslmode=require
-#   export SUPABASE_DB_USERNAME=postgres.eytlhjybvmmmtcvbxyyr
-#   export SUPABASE_DB_PASSWORD=MotoRYX2026
-# On Render, set these as Environment Variables in the dashboard.
+# These values work for local development out of the box.
+# On Render, override them by setting environment variables:
+#   SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD
+# (Spring Boot auto-maps SPRING_DATASOURCE_* env vars to these properties.)
 # ===============================
-spring.datasource.url=${SUPABASE_DB_URL:jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:5432/postgres?sslmode=require}
-spring.datasource.username=${SUPABASE_DB_USERNAME:postgres.eytlhjybvmmmtcvbxyyr}
-spring.datasource.password=${SUPABASE_DB_PASSWORD:MotoRYX2026}
+spring.datasource.url=jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:6543/postgres?sslmode=require&prepareThreshold=0
+spring.datasource.username=postgres.eytlhjybvmmmtcvbxyyr
+spring.datasource.password=MotoRYX2026
+spring.datasource.hikari.maximum-pool-size=5
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # ===============================
 # JPA / Hibernate Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      # Supabase credentials — matches ${SUPABASE_DB_*} in application.properties
-      SUPABASE_DB_URL: jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:5432/postgres?sslmode=require
-      SUPABASE_DB_USERNAME: postgres.eytlhjybvmmmtcvbxyyr
-      SUPABASE_DB_PASSWORD: MotoRYX2026
+      # Spring Boot auto-maps SPRING_DATASOURCE_* to spring.datasource.* properties
+      SPRING_DATASOURCE_URL: jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:6543/postgres?sslmode=require&prepareThreshold=0
+      SPRING_DATASOURCE_USERNAME: postgres.eytlhjybvmmmtcvbxyyr
+      SPRING_DATASOURCE_PASSWORD: MotoRYX2026
     restart: unless-stopped

--- a/render.yaml
+++ b/render.yaml
@@ -14,11 +14,11 @@ services:
     dockerContext: ./Backend/f1-api
     plan: free
     envVars:
-      - key: SUPABASE_DB_URL
+      - key: SPRING_DATASOURCE_URL
         sync: false
-      - key: SUPABASE_DB_USERNAME
+      - key: SPRING_DATASOURCE_USERNAME
         sync: false
-      - key: SUPABASE_DB_PASSWORD
+      - key: SPRING_DATASOURCE_PASSWORD
         sync: false
 
   # ---------- Frontend (React + Vite Static Site) ----------


### PR DESCRIPTION
…t variables

Changed from custom SUPABASE_DB_* variables to Spring Boot's native SPRING_DATASOURCE_* convention for automatic property mapping. Updated Supabase connection to use port 6543 with prepareThreshold=0 parameter. Added HikariCP connection pool size limit and explicit PostgreSQL dialect. Modified docker-compose.yml and render.yaml to reflect new environment variable naming.